### PR TITLE
enable distributed training on local machine

### DIFF
--- a/mace/tools/slurm_distributed.py
+++ b/mace/tools/slurm_distributed.py
@@ -12,7 +12,12 @@ import hostlist
 
 class DistributedEnvironment:
     def __init__(self):
-        self._setup_distr_env()
+
+        try:
+            self._setup_distr_env()
+        except:
+            # handle case where not running under Slurm
+            self._setup_local_distr_env()
         self.master_addr = os.environ["MASTER_ADDR"]
         self.master_port = os.environ["MASTER_PORT"]
         self.world_size = int(os.environ["WORLD_SIZE"])
@@ -32,3 +37,17 @@ class DistributedEnvironment:
         )
         os.environ["LOCAL_RANK"] = os.environ["SLURM_LOCALID"]
         os.environ["RANK"] = os.environ["SLURM_PROCID"]
+
+    def _setup_local_distr_env(self):
+        hostname = "localhost"
+        os.environ["MASTER_ADDR"] = hostname
+        os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", "33333")
+        os.environ["WORLD_SIZE"] = os.environ.get(
+            "SLURM_NTASKS",
+            str(
+                int(os.environ["SLURM_NTASKS_PER_NODE"])
+                * 1
+            ),
+        )
+        os.environ["LOCAL_RANK"] = os.environ["OMPI_COMM_WORLD_LOCAL_RANK"]
+        os.environ["RANK"] = os.environ["OMPI_COMM_WORLD_LOCAL_RANK"]


### PR DESCRIPTION
Normally MACE expects some slurm-specific env variables to be set to configure distirbuted training.  This PR catches the case where these aren't set and uses the appropriate OpenMPI env variables instead