### PR TITLE
added sparsifcation strategy

### DIFF
--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -198,6 +198,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
         target_irreps: o3.Irreps,
         correlation: int,
         use_sc: bool = True,
+        sparse_max: int = 0,
         num_elements: Optional[int] = None,
     ) -> None:
         super().__init__()
@@ -208,6 +209,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
             irreps_out=target_irreps,
             correlation=correlation,
             num_elements=num_elements,
+            sparse_max=sparse_max,
         )
         # Update linear
         self.linear = o3.Linear(

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -61,6 +61,7 @@ class MACE(torch.nn.Module):
         distance_transform: str = "None",
         radial_MLP: Optional[List[int]] = None,
         radial_type: Optional[str] = "bessel",
+        sparse_max: int = 0,
     ):
         super().__init__()
         self.register_buffer(
@@ -127,6 +128,7 @@ class MACE(torch.nn.Module):
             correlation=correlation[0],
             num_elements=num_elements,
             use_sc=use_sc_first,
+            sparse_max=sparse_max,
         )
         self.products = torch.nn.ModuleList([prod])
 
@@ -157,6 +159,7 @@ class MACE(torch.nn.Module):
                 correlation=correlation[i + 1],
                 num_elements=num_elements,
                 use_sc=True,
+                sparse_max=sparse_max,
             )
             self.products.append(prod)
             if i == num_interactions - 2:
@@ -656,6 +659,7 @@ class AtomicDipolesMACE(torch.nn.Module):
         ],  # Just here to make it compatible with energy models, MUST be None
         radial_type: Optional[str] = "bessel",
         radial_MLP: Optional[List[int]] = None,
+        sparse_max: int = 0,
     ):
         super().__init__()
         self.register_buffer(
@@ -715,6 +719,7 @@ class AtomicDipolesMACE(torch.nn.Module):
             correlation=correlation,
             num_elements=num_elements,
             use_sc=use_sc_first,
+            sparse_max=sparse_max,
         )
         self.products = torch.nn.ModuleList([prod])
 
@@ -748,6 +753,7 @@ class AtomicDipolesMACE(torch.nn.Module):
                 correlation=correlation,
                 num_elements=num_elements,
                 use_sc=True,
+                sparse_max=sparse_max,
             )
             self.products.append(prod)
             if i == num_interactions - 2:
@@ -857,6 +863,7 @@ class EnergyDipolesMACE(torch.nn.Module):
         gate: Optional[Callable],
         atomic_energies: Optional[np.ndarray],
         radial_MLP: Optional[List[int]] = None,
+        sparse_max: int = 0,
     ):
         super().__init__()
         self.register_buffer(
@@ -914,6 +921,7 @@ class EnergyDipolesMACE(torch.nn.Module):
             correlation=correlation,
             num_elements=num_elements,
             use_sc=use_sc_first,
+            sparse_max=sparse_max,
         )
         self.products = torch.nn.ModuleList([prod])
 
@@ -947,6 +955,7 @@ class EnergyDipolesMACE(torch.nn.Module):
                 correlation=correlation,
                 num_elements=num_elements,
                 use_sc=True,
+                sparse_max=sparse_max,
             )
             self.products.append(prod)
             if i == num_interactions - 2:

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -61,7 +61,7 @@ class MACE(torch.nn.Module):
         distance_transform: str = "None",
         radial_MLP: Optional[List[int]] = None,
         radial_type: Optional[str] = "bessel",
-        sparse_max: int = 0,
+        symmetric_contraction_sparse_max: int = 0,
     ):
         super().__init__()
         self.register_buffer(
@@ -128,7 +128,7 @@ class MACE(torch.nn.Module):
             correlation=correlation[0],
             num_elements=num_elements,
             use_sc=use_sc_first,
-            sparse_max=sparse_max,
+            sparse_max=symmetric_contraction_sparse_max,
         )
         self.products = torch.nn.ModuleList([prod])
 
@@ -159,7 +159,7 @@ class MACE(torch.nn.Module):
                 correlation=correlation[i + 1],
                 num_elements=num_elements,
                 use_sc=True,
-                sparse_max=sparse_max,
+                sparse_max=symmetric_contraction_sparse_max,
             )
             self.products.append(prod)
             if i == num_interactions - 2:
@@ -659,7 +659,7 @@ class AtomicDipolesMACE(torch.nn.Module):
         ],  # Just here to make it compatible with energy models, MUST be None
         radial_type: Optional[str] = "bessel",
         radial_MLP: Optional[List[int]] = None,
-        sparse_max: int = 0,
+        symmetric_contraction_sparse_max: int = 0,
     ):
         super().__init__()
         self.register_buffer(
@@ -719,7 +719,7 @@ class AtomicDipolesMACE(torch.nn.Module):
             correlation=correlation,
             num_elements=num_elements,
             use_sc=use_sc_first,
-            sparse_max=sparse_max,
+            sparse_max=symmetric_contraction_sparse_max,
         )
         self.products = torch.nn.ModuleList([prod])
 
@@ -753,7 +753,7 @@ class AtomicDipolesMACE(torch.nn.Module):
                 correlation=correlation,
                 num_elements=num_elements,
                 use_sc=True,
-                sparse_max=sparse_max,
+                sparse_max=symmetric_contraction_sparse_max,
             )
             self.products.append(prod)
             if i == num_interactions - 2:
@@ -863,7 +863,7 @@ class EnergyDipolesMACE(torch.nn.Module):
         gate: Optional[Callable],
         atomic_energies: Optional[np.ndarray],
         radial_MLP: Optional[List[int]] = None,
-        sparse_max: int = 0,
+        symmetric_contraction_sparse_max: int = 0,
     ):
         super().__init__()
         self.register_buffer(
@@ -921,7 +921,7 @@ class EnergyDipolesMACE(torch.nn.Module):
             correlation=correlation,
             num_elements=num_elements,
             use_sc=use_sc_first,
-            sparse_max=sparse_max,
+            sparse_max=symmetric_contraction_sparse_max,
         )
         self.products = torch.nn.ModuleList([prod])
 
@@ -955,7 +955,7 @@ class EnergyDipolesMACE(torch.nn.Module):
                 correlation=correlation,
                 num_elements=num_elements,
                 use_sc=True,
-                sparse_max=sparse_max,
+                sparse_max=symmetric_contraction_sparse_max,
             )
             self.products.append(prod)
             if i == num_interactions - 2:

--- a/mace/modules/symmetric_contraction.py
+++ b/mace/modules/symmetric_contraction.py
@@ -29,6 +29,7 @@ class SymmetricContraction(CodeGenMixin, torch.nn.Module):
         correlation: Union[int, Dict[str, int]],
         irrep_normalization: str = "component",
         path_normalization: str = "element",
+        sparse_max: int = 0,
         internal_weights: Optional[bool] = None,
         shared_weights: Optional[bool] = None,
         num_elements: Optional[int] = None,
@@ -75,6 +76,7 @@ class SymmetricContraction(CodeGenMixin, torch.nn.Module):
                     internal_weights=self.internal_weights,
                     num_elements=num_elements,
                     weights=self.shared_weights,
+                    sparse_max=sparse_max,
                 )
             )
 
@@ -91,6 +93,7 @@ class Contraction(torch.nn.Module):
         irrep_out: o3.Irreps,
         correlation: int,
         internal_weights: bool = True,
+        sparse_max: int = 0,
         num_elements: Optional[int] = None,
         weights: Optional[torch.Tensor] = None,
     ) -> None:
@@ -105,6 +108,7 @@ class Contraction(torch.nn.Module):
                 irreps_in=self.coupling_irreps,
                 irreps_out=irrep_out,
                 correlation=nu,
+                sparse_max=sparse_max,
                 dtype=dtype,
             )[-1]
             self.register_buffer(f"U_matrix_{nu}", U_matrix)

--- a/mace/modules/symmetric_contraction.py
+++ b/mace/modules/symmetric_contraction.py
@@ -36,6 +36,8 @@ class SymmetricContraction(CodeGenMixin, torch.nn.Module):
     ) -> None:
         super().__init__()
 
+        self.sparse_max = sparse_max
+
         if irrep_normalization is None:
             irrep_normalization = "component"
 
@@ -102,6 +104,8 @@ class Contraction(torch.nn.Module):
         self.num_features = irreps_in.count((0, 1))
         self.coupling_irreps = o3.Irreps([irrep.ir for irrep in irreps_in])
         self.correlation = correlation
+        self.sparse_max = sparse_max
+
         dtype = torch.get_default_dtype()
         for nu in range(1, correlation + 1):
             U_matrix = U_matrix_real(

--- a/mace/tools/cg.py
+++ b/mace/tools/cg.py
@@ -92,8 +92,10 @@ def U_matrix_real(
     correlation: int,
     normalization: str = "component",
     filter_ir_mid=None,
+    sparse_max=0,
     dtype=None,
 ):
+    assert sparse_max >= 0, f"sparse_max must be >= 0, current value is {sparse_max}"
     irreps_out = o3.Irreps(irreps_out)
     irrepss = [o3.Irreps(irreps_in)] * correlation
     if correlation == 4:
@@ -115,10 +117,10 @@ def U_matrix_real(
     current_ir = wigners[0][0]
     out = []
     stack = torch.tensor([])
-
     for ir, _, base_o3 in wigners:
         if ir in irreps_out and ir == current_ir:
-            stack = torch.cat((stack, base_o3.squeeze().unsqueeze(-1)), dim=-1)
+            if sparse_max == 0 or stack.shape[-1] <= sparse_max:
+                stack = torch.cat((stack, base_o3.squeeze().unsqueeze(-1)), dim=-1)
             last_ir = current_ir
         elif ir in irreps_out and ir != current_ir:
             if len(stack) != 0:


### PR DESCRIPTION
this change adds in ilyes' sparsification strategy for the U tensor used in the symmetric contraction.

adds in a new variable `symmetric_contraction_sparse_max` to all MACE models, with default value of 0. Setting this to non-zero will turn on the sparsification method.